### PR TITLE
Github Readme stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<p align="center">
+    <img src="https://img.shields.io/github/issues/akshitagupta15june/PetMe"> 
+    <img src="https://img.shields.io/github/issues-pr/akshitagupta15june/PetMe">
+    <img src="https://img.shields.io/github/forks/akshitagupta15june/PetMe">
+    <img src="https://img.shields.io/github/stars/akshitagupta15june/PetMe">
+    <img src="https://img.shields.io/github/license/akshitagupta15june/PetMe">
+</p>
+
+
+
 # PetMe
 
 <h3>Join official <a href="https://discord.gg/X3HZAPzykU">Discord Channel</a> for discussion</h3>


### PR DESCRIPTION
Fixes #36 

Added the shields.io badges to reflect the GitHub repo stats (such as issues, PRs, forks, and stars).
Attaching a screenshot below

![image](https://user-images.githubusercontent.com/55613727/193403508-c8687ce4-9fac-4ca9-8bb4-a0f5e2674b4f.png)

Do let me know if anything needs to be changed.