### PR TITLE
Fix about us link on blog page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -52,7 +52,7 @@
         class="w-[100vw] h-1/2 top-0 right-0 p-4 text-center space-y-8 lg:space-y-0 lg:space-x-3 lg:static lg:w-auto flex flex-col rounded-lg border border-gray-100 items-center lg:bg-transparent lg:border-0 lg:flex-row justify-center">
         <li><a href="./index.html"
             class="p-3 text-custom-heading font-bold hover:underline underline-offset-4 turn-red-hover">Home</a></li>
-        <li><a href="#About"
+        <li><a href="./index.html#About"
             class="p-3 text-custom-heading font-bold hover:underline underline-offset-4 turn-red-hover">About Us</a>
         </li>
         <li><a href="./blog.html"


### PR DESCRIPTION
This is to to fix the about us link on the nav bar of the blog page. Now the about us link redirects to the about us section on the homepage.

Issue #266