### PR TITLE
Add transition styling to the back to top button

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,20 @@ function displayContributors(contributorsList) {
   });
 }
 
+function hideBackToTopButton() {
+  const bttButton = document.getElementById("bttbutton");
+
+  window.addEventListener("scroll", function() {
+    if (window.pageYOffset > 0) {
+      bttButton.style.opacity = "1";
+      bttButton.style.transform = 'translateY(0px)';
+    } else {
+      bttButton.style.opacity = "0";
+      bttButton.style.transform = 'translateY(500px)';
+    }
+  });
+}
+
 // get contributors list  from github API
 async function getContributorsList() {
   try {
@@ -35,5 +49,7 @@ async function getContributorsList() {
   }
 }
 
+hideBackToTopButton()
 getContributorsList();
+
 

--- a/style.css
+++ b/style.css
@@ -243,6 +243,9 @@ Fixes contant form color when theme changes
   padding: 18px !important;
   border-radius: 20%;
   font-size: 12px;
+  opacity: 0;
+  transition: all 0.5s;
+  transform: translateY(500px);
  }
 
 #bttbutton:hover {
@@ -250,6 +253,8 @@ Fixes contant form color when theme changes
   color: #ffac46;
   font-weight: 700 !important;
 }
+
+
 
 
 /* End of Back to top button */


### PR DESCRIPTION
- Add transition styling to the existing Back to Top button
- Improve the button's appearance with the transition effect
- Enhance UX by adding animation when the button appears and disappears
- Use CSS opacity transition to achieve the animation effect

![petMebtt](https://user-images.githubusercontent.com/112358229/214996062-02d9a369-9498-4b09-98e1-16b9986b24b6.gif)



