### PR TITLE
fix size of dark mode icon in navbar

### DIFF
--- a/navbar.css
+++ b/navbar.css
@@ -102,6 +102,11 @@
   cursor: pointer;
 }
 
+#theme-toggle img{
+  height: 50px;
+  width: 50px;
+}
+
 /* make the header sticky on scroll */
 #header {
 	position: fixed;


### PR DESCRIPTION
I noticed that when toggling dark mode, there is an inconsistency in the icon sizes. I have resolved this issue and created a pull request named "fix size of dark mode icon in navbar" to address it. Please review and consider merging the changes.

