### PR TITLE
[GSSOC'23 #790] Improved volunteer page

### DIFF
--- a/volunteer.html
+++ b/volunteer.html
@@ -20,9 +20,13 @@
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
     <title>Become a Volunteer : PetMe</title>
     <style>
+        #top{
+            margin-top: 50px;
+        }
+
         #survey-form{
             /* border: 1px solid black; */
-            padding-top: 50px;
+            padding-top: 10px;
             padding-bottom: 50px;
             border-radius: 20px;
             margin: 50px;
@@ -126,7 +130,7 @@
     <section class="text-gray-600 body-font relative bg-[url('Assets/Images/pet-don.jpg')] bg-center bg-no-repeat
         bg-cover">
         <div class="container px-5 py-24 mx-auto card backdrop-blur-sm">
-            <div class="flex flex-col text-center w-full mb-12">
+            <div id="top" class="flex flex-col text-center w-full mb-12">
                 <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-gray-900">
                     Thanks for showing your support
                 </h1>


### PR DESCRIPTION
I have improved the volunteer page the whole message wasn't visible it was hidden under the nav-bar for the issue #790. 

previously:

<img width="730" alt="Screenshot 2023-06-06 at 6 59 51 PM" src="https://github.com/akshitagupta15june/PetMe/assets/112635806/ec5d8642-b429-4f08-8f38-6fe503c03752">

After the change:

<img width="722" alt="Screenshot 2023-06-06 at 7 18 02 PM" src="https://github.com/akshitagupta15june/PetMe/assets/112635806/d2ad279c-0823-48dc-a05e-4ee203f5b085">

Please review the changes and inform me if something has to be modified @akshitagupta15june 
Thank You
