### PR TITLE
Contact button fixed on blog page & Pet News

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -76,7 +76,7 @@
           <a href="./reportstary.html" class="text-custom-heading font-bold hover:underline underline-offset-4 turn-red-hover navbar-item">SOS Report</a>
         </li>
         <li>
-          <a href="#contact">
+          <a href="./index.html#contact">
           <button class="inline-flex items-center bg-header-orange-light border-0 py-2 lg:py-2 text-base px-2 focus:outline-none text_4 font-bold rounded text-base mt-4 md:mt-0">
             Contact Us
             <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-1" viewBox="0 0 24 24">

--- a/news.html
+++ b/news.html
@@ -89,7 +89,7 @@
 							Report</a>
 					</li>
 					<li>
-						<a href="#contact">
+						<a href="./index.html#contact">
 							<button
 								class="inline-flex items-center bg-header-orange-light border-0 py-2 lg:py-2 text-base px-2 focus:outline-none text_4 font-bold rounded text-base mt-4 md:mt-0">
 								Contact Us


### PR DESCRIPTION
### **_Issue_** #1011 

The contact form on the "Pet News" and "Blog" pages did not exist, therefore the button did not work, I redirected the action of the button to the main page where the form is located.