### PR TITLE
add meta tags for previews

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -59,3 +59,4 @@ Contributors
 - [Swapnil Jadhav](https://github.com/Swapnil-2503)
 - [Emily Cruz Gutierrez](https://github.com/emily883)
 - [Vivek Sati](https://github.com/Viveksati5143)
+- [Ricardo Tavares](https://github.com/t-var-s)

--- a/index.html
+++ b/index.html
@@ -27,6 +27,19 @@
       rel="stylesheet"
     />
     <title>PetMe</title>
+    <meta name="title" content="PetMe"/>
+    <meta name="description" content="Adopt a pet. Give life to an animal in need."/>
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://akshitagupta15june.github.io/PetMe/"/>
+    <meta property="og:title" content="PetMe"/>
+    <meta property="og:description" content="Adopt a pet. Give life to an animal in need."/>
+    <meta property="og:image" content="https://akshitagupta15june.github.io/PetMe/Assets/Images/logo.jpg"/>
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://akshitagupta15june.github.io/PetMe/"/>
+    <meta property="twitter:title" content="PetMe"/>
+    <meta property="twitter:description" content="Adopt a pet. Give life to an animal in need."/>
+    <meta property="twitter:image" content="https://akshitagupta15june.github.io/PetMe/Assets/Images/logo.jpg"/>
+
   </head>
 
   <body>


### PR DESCRIPTION
This allows https://akshitagupta15june.github.io/PetMe/ to offer a preview of the site when shared in platforms like Discord or the usual social networks. 