### PR TITLE
🐛 Bug Report: Added 'Hovering Effect' on Social Icons in 'Meet Pets' section

### DIFF
--- a/news.html
+++ b/news.html
@@ -292,7 +292,7 @@
 			<div class="flex-1 flex flex-col items-center justify-center">
 				<div class="text-2xl">Follow us on</div>
 				<div class="flex mt-2 flex-row space-x-3 my-0">
-					<div>
+					<div class="hover:scale-110 transition-all">
 						<a href="#" class="w-5 ml-3">
 							<!-- Facebook icon -->
 							<svg
@@ -308,7 +308,7 @@
 							</svg>
 						</a>
 					</div>
-					<div>
+					<div class="hover:scale-110 transition-all">
 						<a href="#" class="w-10 ml-3 mr-3">
 							<!-- Instagram icon -->
 							<svg
@@ -324,7 +324,7 @@
 							</svg>
 						</a>
 					</div>
-					<div>
+					<div class="hover:scale-110 transition-all">
 						<a
 							href="https://github.com/akshitagupta15june/PetMe"
 							target="_blank"


### PR DESCRIPTION
# What does this PR do?
This PR adds the **Hovering Effect** on the Social Icons in the `Pets News` section.


![Screen Recording](https://github.com/akshitagupta15june/PetMe/assets/80708599/363e323e-4427-446f-8228-af9817866cba)

Fixes #1166

# Additional Information 
Hi @akshitagupta15june, If you consider this PR to get merged, please added the label `hacktoberfest-accepted` to it. It is necessary for the PR to have this label as per the guidelines of Hacktoberfest.