### PR TITLE
Fix: Scroll-to-top button display

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,15 +27,17 @@ function displayContributors(contributorsList) {
 function hideBackToTopButton() {
   const bttButton = document.getElementById("bttbutton");
 
-  window.addEventListener("scroll", function() {
-    if (window.pageYOffset > 0) {
-      bttButton.style.opacity = "1";
-      bttButton.style.transform = 'translateY(0px)';
-    } else {
-      bttButton.style.opacity = "0";
-      bttButton.style.transform = 'translateY(500px)';
-    }
-  });
+  bttButton.addEventListener("click", e => {
+    window.scrollTo({
+      top:0,
+      left:0,
+      behavior:"smooth"
+    })
+  })
+
+  window.addEventListener("scroll", e => {
+    bttButton.style.display = window.scrollY > 20 ? 'block' : 'none';
+  })
 }
 
 // get contributors list  from github API
@@ -107,4 +109,4 @@ document.addEventListener("DOMContentLoaded", function() {
 }
 });
 
-
+// scroll to top function

--- a/style.css
+++ b/style.css
@@ -73,6 +73,7 @@
     outline: none;
     width: 55px;
     transition: all 0.5s ease;
+    display: none;
   }
 
   /* Add this CSS code to hide the meet cards initially */


### PR DESCRIPTION
**Description:**

This PR addresses the issue of the scroll-to-top button always being present, even when the user has just opened the website or when the page is already at the top. The scroll-to-top button **should only be displayed when the user has scrolled down the page.**

**Screenshots:**
_Before (scroll to top button is always present):_

https://github.com/akshitagupta15june/PetMe/assets/110025628/9a630023-2ca2-4caf-93b1-a561049e46ba

_After (scroll to top button appears only when the user scrolls down):_

https://github.com/akshitagupta15june/PetMe/assets/110025628/a585a616-cb81-420b-8d75-ea3636d2439d

**Note to Reviewer:**

I kindly request the reviewer to consider marking this pull request as `"hacktoberfest"` and `"hacktoberfest-accepted"`.
