### PR TITLE
Fix footer font colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -226,12 +226,12 @@
 #facebook {
 }
 .facebook-icon {
-  fill: rgb(91, 90, 179); 
+  fill: #ccc; 
   transition: fill 0.3s; 
 }
 
 .facebook-icon:hover {
-  fill: blue;
+  fill: #0866FF;
 }
 .instagram-icon {
   fill: #bc2a8d; 
@@ -242,12 +242,12 @@
   fill: #405de6; 
 }
 .github-icon {
-  fill: #181717; 
+  fill: #ccc; 
   transition: fill 0.3s; 
 }
 
 .github-icon:hover {
-  fill: #6e5494; 
+  fill: white; 
 }
 
 #google_translate_element select {


### PR DESCRIPTION

## Pull Request details:
- Simple fix: added better default and hover fill colors for the GitHub and Facebook icons in the footer.
- Fixes #1245 

## Any Breaking changes:
None

## Associated Screenshots:
![image](https://github.com/akshitagupta15june/PetMe/assets/56351143/1174eb7d-b8b2-41fb-84e9-b000c15b0f75)



