### PR TITLE
Fixed Favicon not rendering Issue

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/Assets/Images/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/Assets/Images/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/Assets/Images/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="stylesheet" href="./output.css" />
     <link rel="stylesheet" href="./style.css" />

--- a/donate.html
+++ b/donate.html
@@ -6,9 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/Assets/Images/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/Assets/Images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/Assets/Images/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="./output.css">
     <link rel="stylesheet" href="./style.css">

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/Assets/Images/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/Assets/Images/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/Assets/Images/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link
       rel="stylesheet"

--- a/news.html
+++ b/news.html
@@ -6,9 +6,9 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<script src="https://cdn.tailwindcss.com"></script>
-	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-	<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-	<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+	<link rel="apple-touch-icon" sizes="180x180" href="/Assets/Images/apple-touch-icon.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="/Assets/Images/favicon-32x32.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="/Assets/Images/favicon-16x16.png">
 	<link rel="manifest" href="/site.webmanifest">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/3.4.0/remixicon.css" crossorigin="">
 	<link rel="stylesheet" href="./output.css">
@@ -16,7 +16,7 @@
 	<link rel="stylesheet" href="./introSection.css">
 	<link rel="stylesheet" href="./navbar.css">
 	<link rel="stylesheet" href="./mobileView.css">
-	<link rel="icon" type="image/x-icon" href="/Assets/Images/logo.ico">
+	
 	<script defer src="https://unpkg.com/alpinejs@3.2.4/dist/cdn.min.js"></script>
 	<link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
 	<title>Pet News</title>

--- a/reportstary.html
+++ b/reportstary.html
@@ -5,9 +5,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/Assets/Images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/Assets/Images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/Assets/Images/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/3.4.0/remixicon.css" crossorigin="">
   <link rel="stylesheet" href="./output.css">

--- a/volunteer.html
+++ b/volunteer.html
@@ -6,9 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/Assets/Images/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/Assets/Images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/Assets/Images/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/3.4.0/remixicon.css" crossorigin="">
     <link rel="stylesheet" href="./output.css">


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #1300 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->
It was observed that some pages did not have favicon upon visiting.
namely: `pet news` , `volunteer` or `donate` 
## Screenshots


<img width="342" alt="image" src="https://github.com/akshitagupta15june/PetMe/assets/110724849/110578e4-f2dd-4882-af09-e66c603a7829">

<img width="310" alt="image" src="https://github.com/akshitagupta15june/PetMe/assets/110724849/a0601f05-7980-4c85-9fd3-7f5cbbb96c96">

<img width="347" alt="image" src="https://github.com/akshitagupta15june/PetMe/assets/110724849/3f7bcc66-cfb6-4cd4-a077-15f47823f9ac">



## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
