### PR TITLE
Fixes issue #1324: Enlarges PetMe logo upon hover in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,7 +934,7 @@
           <div>
             <a href="#top">
               <img
-                class="rounded-full w-24 cursor-pointer"
+                class="rounded-full w-24 cursor-pointer hover:scale-110"
                 src="./Assets/Images/logo.jpg"
                 alt="logo"
               />


### PR DESCRIPTION
## Related Issue

Closes #1324 

## Description

The PetMe logo in the header enlarges upon hover currently.
To keep the same continuity in the footer and better visual appeal, this PR does the same by making CSS changes inline using Tailwind CSS classes.

## Screenshots

Before:
![Before_Footer](https://github.com/akshitagupta15june/PetMe/assets/69362333/1a81eb47-b5e7-48dc-83df-fe06cbc3b900)

After changes:
![After_Footer](https://github.com/akshitagupta15june/PetMe/assets/69362333/e505bff7-f87f-42e2-ac91-317cd4c638f4)


## Checklist 

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
