### PR TITLE
Fixes issue #1345 : Improved readability for sub-heading

### DIFF
--- a/introSection.css
+++ b/introSection.css
@@ -62,6 +62,7 @@
   font-size: 20px;
   font-weight: 400;
   letter-spacing: 3px;
+  color: white;
 }
 .main-body-heading-text span{
   color: #c97f06;
@@ -144,7 +145,7 @@
 
 .card-img-size {
   width: 330px;
-  height: 330px; 
+  height: 330px;
   object-fit: cover;
   object-position: 25% 75%;;
 }


### PR DESCRIPTION
## Related Issue

Closes #1345 

## Description

Now the colour of the subheading stays white upon toggling the theme to light mode. A simple CSS style change has been made to the 'introSection.css' file.

## Screenshots

Before:
![Switch_Sub](https://github.com/akshitagupta15june/PetMe/assets/69362333/bd379512-7afc-400f-87e9-6e62dcc18260)

After changes:
![Switch_Sub_After](https://github.com/akshitagupta15june/PetMe/assets/69362333/2082a332-2fec-4a87-98bc-d4454c906b16)

## Checklist 

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
