### PR TITLE
Fixed: Overriding CSS Properties of Google Translate Bar

### DIFF
--- a/navbar.css
+++ b/navbar.css
@@ -143,7 +143,8 @@
 }
 
 .goog-te-gadget {
-  font-size:0px;
+  font-size:0px !important;
+  margin-bottom: -27px;
 }
 
 .skiptranslate goog-te-gadget #text{


### PR DESCRIPTION
Fixes: #1350

**Bug Fixed:-**
In the navbar below the translate searchbar "Powered By" is written whose sense is incomplete without "Powered by Google".
Upon inspecting I found that CSS has been written to hide it, "Google Translate" img is hidden by that but it is not being reflected on "Powered By", it is being overridden by some other properties.
I have fixed that issue.



**Before**
![image](https://github.com/akshitagupta15june/PetMe/assets/140608790/2c6c4c26-6365-4578-a0c7-81e6a7cd9448)

**After**
![image](https://github.com/akshitagupta15june/PetMe/assets/140608790/c4295db7-83b2-40a1-bdc1-e5d4da305f13)

