### PR TITLE
Fixed light-theme text color in Contact Form

### DIFF
--- a/index.html
+++ b/index.html
@@ -718,10 +718,10 @@
           class="bg-gray-100 rounded-md bg-clip-padding backdrop-filter backdrop-blur-sm bg-opacity-20 border border-gray-100 px-8 pt-8 pb-10"
         >
           <p id="contact"></p>
-          <h2 class="text-3xl mt-1 mb-2 text-center bold-500 text_3">
+          <h2 class="text-3xl mt-1 mb-2 text-center bold-500 text-white">
             CONTACT US
           </h2>
-          <p class="text-base text-center text_3">
+          <p class="text-base text-center text-white">
             Any issues! Fill the form below and our team will contact you
             shortly.
           </p>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #1364

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->
The text color of the heading of the Contact Form in the Index page is not visible and not matching the overall design in the light mode. It can be white in color as other texts in the Contact Form remain unchanged as white for both light and dark modes

## Screenshots

<!-- Add screenshots to preview the changes  -->
Before:
![PetMe-ContactForm-Before-LightTheme](https://github.com/akshitagupta15june/PetMe/assets/58381512/93459d0a-fa5d-4247-aa0b-aee0a2438496)

After:
![PetMe-ContactForm-After-LightTheme](https://github.com/akshitagupta15june/PetMe/assets/58381512/e8e70956-6385-4a69-9719-5e813df1fb18)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
