### PR TITLE
added button to link volunteer page to increase conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,6 +260,25 @@
           stray animals in need of immediate assistance. Together, we can create
           a better world for all animals.
         </p>
+        <a href="./volunteer.html" class="block mx-auto w-fit ">
+          <button
+            class="inline-flex items-center hover:bg-amber-800 border-0 py-2 lg:py-2  text-base px-2 focus:outline-none text-white font-bold rounded text-base mt-4 md:mt-0 hover:translate-x-2 transition-transform bg-transparent "
+          >
+            Become Volunteer
+            <svg
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              class="w-4 h-4 ml-1 transform translate-x-0 transition-transform"
+              viewBox="0 0 24 24"
+            >
+              <path d="M5 12h14M12 5l7 7-7 7"></path>
+            </svg>
+          </button>
+        </a>
+        
       </div>
     </section>
 


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #1367 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->
Usually websites have call-to-action button to increase the conversion of users to do specific task for example: Register, Sign-In, Volunteer, Participate, etc. One of the main idea and motive behind this initiative is to connect people to create a better world for all animals but the site is missing a strong call for people to come together. So to overcome this we can either have a CTA button or a CTA link in the About Us section of Index Page that takes the user to the Volunteer page


## Screenshots

<!-- Add screenshots to preview the changes  -->
CTA Button:
![PetMe-after-update1](https://github.com/akshitagupta15june/PetMe/assets/58381512/8bf2b511-46b7-4718-b695-83dc8bfe6cbd)

CTA Button when hovered:
![PetMe-after-update2](https://github.com/akshitagupta15june/PetMe/assets/58381512/9340ec8c-6d97-43d7-b307-97b5fcb27be5)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
