### PR TITLE
Fixed button size glitch in light and dark theme

### DIFF
--- a/navbar.css
+++ b/navbar.css
@@ -8,30 +8,29 @@
   color: rgb(51 50 49 / var(--tw-bg-opacity));
 }
 
-.turn-red-hover:hover {
+#switch{
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: color .3s;
+}
+
+#switch.light-theme {
+  color: white;
+}
+
+#switch.dark-theme {
+  color: rgb(62, 62, 62);;
+}
+
+
+#switch.turn-red-hover:hover {
   --tw-text-opacity: 0.65;
   color: rgb(255 0 0 / var(--tw-text-opacity));
-  transition-duration: 0.3s;
 }
 
-.turn-yellow-hover:hover {
+#switch.turn-yellow-hover:hover {
   --tw-text-opacity: 0.65;
   color: rgb(255 177 0 / var(--tw-text-opacity));
-  transition-duration: 0.3s;
-}
-
-.light-theme {
-  font-size: 1.5rem;
-  color: white;
-  cursor: pointer;
-  transition: color .3s;
-}
-
-.dark-theme {
-  font-size: 1.5rem;
-  color: rgb(62, 62, 62);;
-  cursor: pointer;
-  transition: color .3s;
 }
 
 .bg-header-orange-light {


### PR DESCRIPTION
## Related Issue

Closes: #1363

## Description

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->

Whenever theme toggle button be clicked, the dark-theme class get toggled but the light-theme class not, it applies font-size:1.5 for the whole body tag, leads to the glitch in font size of the Submit button (as well as the placeholder of the text area right above and maybe somewhere else).
I gather all the common styles and put all of them into '#switch', keep only necessary styles used for switch button, add prefix "#switch" in order to use .dark-theme locally, as well as increase priority of :hover actions, ensure that their color style are not overwritten by .dark-theme class.

## Screenshots
![Screenshot 2023-10-29 at 6 06 02 pm](https://github.com/akshitagupta15june/PetMe/assets/15803788/4b3a9d35-673a-4518-88d3-0ca3c97bc3af)

![Screenshot 2023-10-29 at 6 06 11 pm](https://github.com/akshitagupta15june/PetMe/assets/15803788/64074279-1a51-4b06-9856-68ae392e0e64)

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
