### PR TITLE
#1403 solved

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,10 +737,10 @@
           class="bg-black rounded-md main-bg-clip-padding backdrop-filter backdrop-blur-sm bg-opacity-20 border border-gray-100 px-8 pt-8 pb-10"
         >
           <p id="contact"></p>
-          <h2 class="text-3xl mt-1 mb-2 text-center bold-500 text_3">
+          <h2 class="text-3xl mt-1 mb-2 text-center bold-500 text_3" style="color: white;">
             CONTACT US
           </h2>
-          <p class="text-base text-center text_3">
+          <p class="text-base text-center text_3" style="color: white;">
             Any issues! Fill the form below and our team will contact you
             shortly.
           </p>
@@ -748,7 +748,7 @@
           <div class="mb-4">
             <label
               class="block text_3 text-sm font-bold mb-2"
-              for="contact_nom"
+              for="contact_nom" style="color: white;"
             >
               Name
             </label>
@@ -763,7 +763,7 @@
           <div class="mb-6">
             <label
               class="block text_3 text-sm font-bold mb-2"
-              for="contact_email"
+              for="contact_email" style="color: white;"
             >
               Email
             </label>
@@ -779,7 +779,7 @@
           <div class="mb-6">
             <label
               for="contact_message"
-              class="block text_3 text-sm font-bold mb-2"
+              class="block text_3 text-sm font-bold mb-2" style="color: white;"
               >Message</label
             >
             <textarea


### PR DESCRIPTION
text in Contact Us section of main page is now visible in dark and light mode

Closes: #1403


## Screenshots

Before:
![before (3)](https://github.com/akshitagupta15june/PetMe/assets/37825309/6cd4b126-266c-467c-b166-3570e6eb20ee)
![before (4)](https://github.com/akshitagupta15june/PetMe/assets/37825309/622a2361-3e46-452f-9cc9-5b27fe56031c)

After:
![after (1)](https://github.com/akshitagupta15june/PetMe/assets/37825309/6d9f0f5f-a11b-4ac8-a132-70ad6d5e3b31)
![after (2)](https://github.com/akshitagupta15june/PetMe/assets/37825309/2cedcd62-bb66-4eb9-a5e1-28190f542a8f)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [ ] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [ ] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
