### PR TITLE
fixing problem making top of card shown when link meet pet clicked an…

### DIFF
--- a/introSection.css
+++ b/introSection.css
@@ -95,6 +95,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
+  scroll-margin-top:96px;
 }
 
 .main-img {


### PR DESCRIPTION
…d goes to

<!-- Pull Request Template -->

##1485
gh-1485

Closes: #issue_number

gh-1485

## Description
I modified introSection.css adding scroll-margin-top:96px to .one-line-card so it fixes the problem
## Screenshots
![fix-covering-top](https://github.com/akshitagupta15june/PetMe/assets/73184801/08681f38-a405-4a9c-aa65-5c6b58266ac6)
## Checklist 
- [ x] My code adheres to the established style guidelines of the project.
- [x ] I have included comments in areas that may be difficult to understand.
- [x ] My changes have not introduced any new warnings.
- [x ] I have conducted a self-review of my code.
