### PR TITLE
Fix the read button goes out it's parent block (#1562)

### DIFF
--- a/blog.js
+++ b/blog.js
@@ -18,7 +18,7 @@ fetch("blog.json")
               <span class="text-base font-light lowercase py-3">${blog.description}</span>
             </h3>
             <div>
-               <a href="${blog.read}" rel="noopener noreferrer" class="pl-6 pr-6 m-auto mt-0 mb-0 text-white font-normal bg-amber-800 hover:bg-amber-900 rounded-md py-3 transition duration-300 ease-in-out focus:outline-none focus:ring focus:border-amber-900 transform hover:scale-105" aria-label="Read ${blog.title}">
+               <a href="${blog.read}" rel="noopener noreferrer" class="pl-6 pr-6 m-auto mt-0 mb-0 text-white font-normal bg-amber-800 hover:bg-amber-900 rounded-md py-2 transition duration-300 ease-in-out focus:outline-none focus:ring focus:border-amber-900 transform hover:scale-105 inline-block" aria-label="Read ${blog.title}">
                 <b>Read</b>
               </a>
             </div>

--- a/blog.js
+++ b/blog.js
@@ -18,7 +18,7 @@ fetch("blog.json")
               <span class="text-base font-light lowercase py-3">${blog.description}</span>
             </h3>
             <div>
-               <a href="${blog.read}" rel="noopener noreferrer" class="pl-6 pr-6 m-auto mt-0 mb-0 text-white font-normal bg-amber-800 hover:bg-amber-900 rounded-md py-2 transition duration-300 ease-in-out focus:outline-none focus:ring focus:border-amber-900 transform hover:scale-105 inline-block" aria-label="Read ${blog.title}">
+               <a href="${blog.read}" rel="noopener noreferrer" class="pl-6 pr-6 m-auto mt-0 mb-2 text-white font-normal bg-amber-800 hover:bg-amber-900 rounded-md py-2 transition duration-300 ease-in-out focus:outline-none focus:ring focus:border-amber-900 transform hover:scale-105 inline-block" aria-label="Read ${blog.title}">
                 <b>Read</b>
               </a>
             </div>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #issue_number

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->
issue number: (#1562)


## Description

Made a minimal changes ensuring read button is inside a parent block. 

## Screenshots

![image](https://github.com/akshitagupta15june/PetMe/assets/26418357/bd06eb20-0df3-40c1-9712-06d1e23be7fc)

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
