### PR TITLE
fixed position of help button in sos while scroll 

### DIFF
--- a/reportstary.css
+++ b/reportstary.css
@@ -266,8 +266,9 @@ nav ul li a:hover::after {
 /* help css */
 .help_btn{
 
-  position: absolute;
-  left:75%;
+  position: fixed;
+  right: 2%;
+  z-index: 100;
 
   bottom: 10%;
   font-size: 1rem;


### PR DESCRIPTION
help button position fixed

<!-- Pull Request Template -->

## Related Issue #1530  #1582 

Closes: #issue_number

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

change the css of help button now it fixed to right side of screen .

## Screenshots

<!-- Add screenshots to preview the changes  -->
![Screenshot 2024-05-23 155049](https://github.com/akshitagupta15june/PetMe/assets/143947231/f8781248-1b3a-481e-856a-8f05824adbd2)



## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [ ] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [ ] My changes have not introduced any new warnings.
- [ ] I have conducted a self-review of my code.
