### PR TITLE
Fixed bug in Split screen for Support Us dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,11 +117,7 @@
               >
             </li>
             <li>
-              <div
-                x-data="{ open: false }"
-                @mouseleave="open = false"
-                class="relative"
-              >
+              <div x-data="{ open: false }" @mouseleave="open = false" class="relative">
                 <a
                   @mouseover="open = true"
                   class="text-custom-heading flex font-bold hover:underline underline-offset-4 turn-red-hover navbar-item w-full"
@@ -146,15 +142,17 @@
                 </a>
                 <div
                   x-show="open"
-                  class="z-20 absolute -left-1 w-[7.5rem] py-2 bg-gray-100 rounded-md shadow-xl"
+                  class="z-20 absolute left-0 w-max py-2 bg-gray-100 rounded-md shadow-xl overflow-hidden"
                 >
                   <a
                     href="volunteer.html"
                     class="block px-4 py-2 text-base text-gray-600 hover:bg-gray-400 hover:text-white"
-                    >Become a Volunteer</a
                   >
+                    Become a Volunteer
+                  </a>
                 </div>
               </div>
+              
             </li>
             <li>
               <a


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #1668 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

One common issue is that the absolute positioning combined with the fixed width (w-[7.5rem]) might cause the content to overflow the container in smaller screen widths.

To overcome this problem we can introduce -
1. Responsive Width: Instead of using a fixed width, we can use a responsive width (min-w or max-w) to allow the dropdown to adjust based on its content.

2. Overflow Handling: Ensure the content doesn't overflow by using overflow-hidden.

3. Adjust Padding and Margins: Fine-tune the padding and margins to ensure the content is well-positioned within the box.

## Screenshots

![bug fixed](https://github.com/akshitagupta15june/PetMe/assets/144598258/471b4fa2-9d71-49db-b749-ef416caae5eb)

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
