### PR TITLE
Fix button overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,20 +668,7 @@
         </div>
       </form>
     </div>
-    
-    <!-- Dark Mode Toggle Button -->
-    <div class="fixed bottom-4 right-4">
-      <button id="darkModeToggle" class="bg-gray-200 dark:bg-gray-700 p-2 rounded-full shadow-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-all duration-200">
-        <!-- Sun icon (for dark mode) -->
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-amber-600 dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-        </svg>
-        <!-- Moon icon (for light mode) -->
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-200 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-        </svg>
-      </button>
-    </div>
+
     
     <!-- Validation Scripts -->
     <script>
@@ -745,6 +732,30 @@
       });
     </script>
   </section>
+
+  <!-- Scroll to Top Button -->
+  <!-- Scroll to Top Button -->
+  <!-- Scroll to Top Button -->
+  <button id="bttbutton" class="fixed bottom-4 w-10 h-10 bg-amber-500 dark:bg-amber-600 rounded-full shadow-lg hover:bg-amber-600 dark:hover:bg-amber-700 transition-all duration-200 flex items-center justify-center hidden" style="right: 4rem;" title="Back to top">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
+    </svg>
+  </button>
+
+
+  <!-- Dark Mode Toggle Button -->
+  <div class="fixed bottom-4 right-4">
+    <button id="darkModeToggle" class="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-full shadow-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-all duration-200 flex items-center justify-center">
+      <!-- Sun icon (for dark mode) -->
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-amber-600 dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+      </svg>
+      <!-- Moon icon (for light mode) -->
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-200 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+      </svg>
+    </button>
+  </div>
   
   <script>
       window.addEventListener("scroll", function () {
@@ -919,14 +930,7 @@
       <!-- Social icons end -->
 
       <!-- Scroll to top -->
-      <div class="md:pr-8 hover-effect">
-        <a href="#top">
-          <button id="bttbutton" title="backtotop">
-            <img src="./image.svg" class="w-6 md:w-10 md:object-left sm:w-10" />
-          </button>
-        </a>
-      </div>
-      <!-- Scroll to top -->
+      
     </div>
 
     <div class="pt-5 pb-8 flex flex-col text-center md:hidden mt-8 items-center flex-1">

--- a/index.html
+++ b/index.html
@@ -734,8 +734,6 @@
   </section>
 
   <!-- Scroll to Top Button -->
-  <!-- Scroll to Top Button -->
-  <!-- Scroll to Top Button -->
   <button id="bttbutton" class="fixed bottom-4 w-10 h-10 bg-amber-500 dark:bg-amber-600 rounded-full shadow-lg hover:bg-amber-600 dark:hover:bg-amber-700 transition-all duration-200 flex items-center justify-center hidden" style="right: 4rem;" title="Back to top">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function displayContributors(contributorsList) {
 function hideBackToTopButton() {
   const bttButton = document.getElementById("bttbutton");
 
-  bttButton.addEventListener("click", (e) => {
+  bttButton.addEventListener("click", () => {
     window.scrollTo({
       top: 0,
       left: 0,
@@ -34,10 +34,15 @@ function hideBackToTopButton() {
     });
   });
 
-  window.addEventListener("scroll", (e) => {
-    bttButton.style.display = window.scrollY > 15 ? "block" : "none";
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 100) {
+      bttButton.classList.remove("hidden");
+    } else {
+      bttButton.classList.add("hidden");
+    }
   });
 }
+
 
 // get contributors list  from github API
 async function getContributorsList() {
@@ -50,8 +55,11 @@ async function getContributorsList() {
   }
 }
 
-hideBackToTopButton();
-getContributorsList();
+document.addEventListener("DOMContentLoaded", () => {
+  hideBackToTopButton();
+  getContributorsList();
+});
+
 
 function googleTranslateElementInit() {
   new google.translate.TranslateElement(


### PR DESCRIPTION
<!-- Pull Request Template -->

## 🪲[Bug]: Dark mode toggle and "Go to Top" button overlap on bottom-right corner #2015

Closes: #2015 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description
My changes fixed the overlap of the dark mode toggle and scroll to top button
<!--  -->

## Screenshots
<img width="143" height="95" alt="Screenshot 2026-02-16 at 11 05 35 PM" src="https://github.com/user-attachments/assets/d23d0bab-c4f2-40cb-841f-3e363b6f5292"
<!-- 
<img width="143" height="95" alt="Screenshot 2026-02-16 at 11 05 35 PM" src="https://github.com/user-attachments/assets/d23d0bab-c4f2-40cb-841f-3e363b6f5292" />
 -->

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
