### PR TITLE
Issue #2016 fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </a>
-              <div x-show="open" class="z-20 absolute -left-1 w-[7.5rem] py-2 bg-gray-100 rounded-md shadow-xl hover:bg-gray-400 ">
+              <div x-show="open" class="z-20 absolute left-1/2 -translate-x-1/2 w-[auto] py-2 bg-gray-100 rounded-md shadow-xl hover:bg-gray-400 ">
                 <a href="volunteer.html" class=" remover block px-4 py-2 text-base text-gray-300 text-gray-700 hover:text-white">Become a Volunteer</a>
               </div>
               </div>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Issue

Closes: #2016 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The Support Us drop-down text misalignment in mobile navigation was fixed; the 'Become a Volunteer' is now centered and no longer overlaps the text with the background.

## Screenshots

<img width="679" height="1028" alt="image" src="https://github.com/user-attachments/assets/312dc26c-8df2-41e0-903e-525b8bf5ded2" />

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
