### PR TITLE
Charleykennedy

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                 </svg>
               </a>
               <div x-show="open" class="z-20 absolute left-1/2 -translate-x-1/2 w-[auto] py-2 bg-gray-100 rounded-md shadow-xl hover:bg-gray-400 ">
-                <a href="volunteer.html" class=" remover block px-4 py-2 text-base text-gray-300 text-gray-700 hover:text-white">Become a Volunteer</a>
+                <a href="volunteer.html" class=" remover block px-4 py-2 whitespace-nowrap text-base text-gray-300 text-gray-700 hover:text-white">Become a Volunteer</a>
               </div>
               </div>
 

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </a>
-              <div x-show="open" class="z-20 absolute -left-1 w-[7.5rem] py-2 bg-gray-100 rounded-md shadow-xl hover:bg-gray-400 ">
+              <div x-show="open" class="z-20 absolute left-1/2 -translate-x-1/2 w-[auto] py-2 bg-gray-100 rounded-md shadow-xl hover:bg-gray-400 ">
                 <a href="volunteer.html" class=" remover block px-4 py-2 text-base text-gray-300 text-gray-700 hover:text-white">Become a Volunteer</a>
               </div>
               </div>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #2016 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The 'Support Us' dropdown text misalignment in mobile navigation was fixed; the 'Become a Volunteer' text is now centered and no longer overlaps with the background. However, in order to implement this, the desktop version of the same text had to be altered to be on one line instead of two. 

## Screenshots

<img width="676" height="1031" alt="image" src="https://github.com/user-attachments/assets/95700451-819d-41a1-a910-d508ed3535ff" />
<img width="2271" height="242" alt="image" src="https://github.com/user-attachments/assets/8755e572-b2b6-430b-8cb9-efa40d113de5" />


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
